### PR TITLE
Parse timer-count from BLE timer reply and centralize device info for entities

### DIFF
--- a/A550/a550_codex_project/custom_components/a550/bluetooth.py
+++ b/A550/a550_codex_project/custom_components/a550/bluetooth.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Callable
 
 from bleak import BleakClient
-
 from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -47,6 +46,7 @@ class A550Data:
     battery_percent: int | None
     probes: dict[int, ProbeReading]
     timers: dict[int, list[int]]
+    timer_counts: dict[int, int]
 
 
 class A550Client:
@@ -71,6 +71,7 @@ class A550Client:
                 for idx in range(PROBE_COUNT)
             },
             timers={idx: [0] * TIMER_SLOT_COUNT for idx in range(PROBE_COUNT)},
+            timer_counts={idx: 0 for idx in range(PROBE_COUNT)},
         )
 
     async def async_update(self) -> A550Data:
@@ -87,6 +88,10 @@ class A550Client:
             }
             timers: dict[int, list[int]] = {
                 idx: list(self._last_data.timers.get(idx, [0] * TIMER_SLOT_COUNT))
+                for idx in range(PROBE_COUNT)
+            }
+            timer_counts: dict[int, int] = {
+                idx: int(self._last_data.timer_counts.get(idx, 0))
                 for idx in range(PROBE_COUNT)
             }
 
@@ -114,7 +119,9 @@ class A550Client:
                         self._pkt_request_timer_settings(probe_id, self._device_nonce),
                         response=True,
                     )
-                    timers[probe_id] = await self._async_wait_for_timer_packet(self._queue, probe_id)
+                    timer_count, probe_timers = await self._async_wait_for_timer_packet(self._queue, probe_id)
+                    timer_counts[probe_id] = timer_count
+                    timers[probe_id] = probe_timers
             except Exception as err:  # noqa: BLE001
                 await self.async_disconnect()
                 raise UpdateFailed(f"Failed to poll A550 at {self.address}: {err}") from err
@@ -125,6 +132,7 @@ class A550Client:
                 battery_percent=battery_holder["value"],
                 probes=probes,
                 timers=timers,
+                timer_counts=timer_counts,
             )
             return self._last_data
 
@@ -164,9 +172,11 @@ class A550Client:
                 current = [0] * TIMER_SLOT_COUNT
             current[slot] = int(value)
 
+            timer_count = self._last_data.timer_counts.get(probe_id, TIMER_SLOT_COUNT)
+
             await client.write_gatt_char(
                 CTRL_CHAR_UUID,
-                self._pkt_set_timer(probe_id, TIMER_SLOT_COUNT, current, self._device_nonce),
+                self._pkt_set_timer(probe_id, timer_count, current, self._device_nonce),
                 response=True,
             )
             await self._async_wait_for_packet(
@@ -301,15 +311,19 @@ class A550Client:
                 if probe_id == requested_probe_id:
                     return
 
-    async def _async_wait_for_timer_packet(self, queue: asyncio.Queue[bytes], probe_id: int) -> list[int]:
+    async def _async_wait_for_timer_packet(
+        self,
+        queue: asyncio.Queue[bytes],
+        probe_id: int,
+    ) -> tuple[int, list[int]]:
         while True:
             packet = await self._async_wait_for_packet(
                 queue,
                 lambda pkt: len(pkt) >= 19 and pkt[0] == 0x83 and pkt[1] == 0x13,
             )
-            pkt_probe, timers = self._parse_timer_settings(packet)
+            pkt_probe, timer_count, timers = self._parse_timer_settings(packet)
             if pkt_probe == probe_id:
-                return timers
+                return timer_count, timers
 
     async def _async_wait_for_packet(self, queue: asyncio.Queue[bytes], matcher: Callable[[bytes], bool]) -> bytes:
         while True:
@@ -447,7 +461,7 @@ class A550Client:
         )
 
     @staticmethod
-    def _parse_timer_settings(packet: bytes) -> tuple[int, list[int]]:
+    def _parse_timer_settings(packet: bytes) -> tuple[int, int, list[int]]:
         timers = [0] * TIMER_SLOT_COUNT
         timers[0] = ((packet[3] & 0xE0) << 3) | packet[2]
         timers[1] = ((packet[4] & 0xFC) << 3) | (packet[3] & 0x1F)
@@ -460,7 +474,9 @@ class A550Client:
         timers[8] = ((packet[14] & 0xE0) << 3) | packet[13]
         timers[9] = ((packet[15] & 0xFC) << 3) | (packet[14] & 0x1F)
         probe_id = (packet[16] >> 4) & 0x0F
-        return probe_id, timers
+        # Android app protocol appears to store active timer count in the low nibble.
+        timer_count = packet[16] & 0x0F
+        return probe_id, timer_count, timers
 
     @staticmethod
     def cooking_status_name(code: int | None) -> str | None:

--- a/A550/a550_codex_project/custom_components/a550/entity.py
+++ b/A550/a550_codex_project/custom_components/a550/entity.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN
+from .coordinator import A550Coordinator
+
+
+def build_device_info(coordinator: A550Coordinator) -> DeviceInfo:
+    """Build shared device metadata for A550 entities."""
+    address = coordinator.client.address
+    return DeviceInfo(
+        connections={(CONNECTION_BLUETOOTH, address)},
+        identifiers={(DOMAIN, address)},
+        name=coordinator.client.name,
+        manufacturer="Clas Ohlson / Grill Smart",
+        model="A550",
+    )
+

--- a/A550/a550_codex_project/custom_components/a550/number.py
+++ b/A550/a550_codex_project/custom_components/a550/number.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, PROBE_COUNT, TIMER_SLOT_COUNT
 from .coordinator import A550Coordinator
+from .entity import build_device_info
 
 
 async def async_setup_entry(
@@ -40,14 +39,7 @@ class A550TimerNumber(CoordinatorEntity[A550Coordinator], NumberEntity):
         self._slot = slot
         self._attr_unique_id = f"{coordinator.client.address}_probe_{probe_id}_timer_{slot}"
         self._attr_translation_placeholders = {"probe": str(probe_id), "slot": str(slot)}
-        address = coordinator.client.address
-        self._attr_device_info = DeviceInfo(
-            connections={(CONNECTION_BLUETOOTH, address)},
-            identifiers={(DOMAIN, address)},
-            name=coordinator.client.name,
-            manufacturer="Clas Ohlson / Grill Smart",
-            model="A550",
-        )
+        self._attr_device_info = build_device_info(coordinator)
 
     @property
     def native_value(self) -> float | None:

--- a/A550/a550_codex_project/custom_components/a550/select.py
+++ b/A550/a550_codex_project/custom_components/a550/select.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, PROBE_COUNT, SETTABLE_COOKING_STATUS
 from .coordinator import A550Coordinator
+from .entity import build_device_info
 
 OPTIONS = list(SETTABLE_COOKING_STATUS.keys())
 
@@ -33,14 +32,7 @@ class A550CookingStatusSelect(CoordinatorEntity[A550Coordinator], SelectEntity):
         self._probe_id = probe_id
         self._attr_unique_id = f"{coordinator.client.address}_probe_{probe_id}_cooking_status"
         self._attr_translation_placeholders = {"probe": str(probe_id)}
-        address = coordinator.client.address
-        self._attr_device_info = DeviceInfo(
-            connections={(CONNECTION_BLUETOOTH, address)},
-            identifiers={(DOMAIN, address)},
-            name=coordinator.client.name,
-            manufacturer="Clas Ohlson / Grill Smart",
-            model="A550",
-        )
+        self._attr_device_info = build_device_info(coordinator)
 
     @property
     def current_option(self) -> str | None:

--- a/A550/a550_codex_project/custom_components/a550/sensor.py
+++ b/A550/a550_codex_project/custom_components/a550/sensor.py
@@ -1,19 +1,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Any
+from typing import Any, Callable
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorEntityDescription, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfTemperature
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ASSUME_FAHRENHEIT, DOMAIN, PROBE_COUNT
 from .coordinator import A550Coordinator
+from .entity import build_device_info
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -70,14 +74,7 @@ class A550BaseSensor(CoordinatorEntity[A550Coordinator], SensorEntity):
     def __init__(self, coordinator: A550Coordinator, description: A550SensorDescription) -> None:
         super().__init__(coordinator)
         self.entity_description = description
-        address = coordinator.client.address
-        self._attr_device_info = DeviceInfo(
-            connections={(CONNECTION_BLUETOOTH, address)},
-            identifiers={(DOMAIN, address)},
-            name=coordinator.client.name,
-            manufacturer="Clas Ohlson / Grill Smart",
-            model="A550",
-        )
+        self._attr_device_info = build_device_info(coordinator)
 
 
 class A550ProbeSensor(A550BaseSensor):

--- a/A550/a550_codex_project/docs/handover.md
+++ b/A550/a550_codex_project/docs/handover.md
@@ -15,6 +15,7 @@
 
 - Cooking status semantics are partially inferred from reverse-engineering.
 - Timer slot semantics are still not fully mapped.
+- Timer arrays are bit-packed and include an inferred timer-count nibble in timer reply packets.
 - There are no automated tests yet.
 - Manifest documentation and issue tracker URLs are placeholders.
 - Reconnect handling works, but could be made more robust if the device drops idle sessions.

--- a/A550/a550_codex_project/docs/protocol.md
+++ b/A550/a550_codex_project/docs/protocol.md
@@ -91,6 +91,18 @@ Fields parsed from current implementation:
 
 On the tested unit, the raw current temperature behaves like Fahrenheit. Home Assistant should convert for display based on its own unit system.
 
+
+### Timer settings
+
+```text
+83 13 ...
+```
+
+Observed from packet parsing in this integration:
+- payload bytes encode 10 timer values using bit packing
+- byte 16 high nibble: probe id
+- byte 16 low nibble: timer count / active-slot count (inferred)
+
 ### Error packet
 
 ```text


### PR DESCRIPTION
### Motivation
- The device replies for timer settings include an active-timer-count nibble which should be preserved and used when writing timer arrays back to the device. 
- Multiple entity modules duplicately constructed `DeviceInfo`, so a shared helper reduces repetition and keeps metadata consistent. 
- Packet parsing needs to expose the inferred timer-count to avoid writing incorrect array lengths to the device. 
- Documentation should reflect the inferred timer-count behavior observed in the protocol.

### Description
- Add `timer_counts` to `A550Data` and populate it during `async_update` from the parsed timer reply. 
- Update `_parse_timer_settings` to return `(probe_id, timer_count, timers)` and document that the low nibble of byte 16 is the inferred timer-count. 
- Adjust `_async_wait_for_timer_packet` and callers to accept the returned `timer_count` and timer list. 
- Use the stored `timer_count` when sending `set_timer` packets in `async_set_timer_value` instead of a fixed `TIMER_SLOT_COUNT`. 
- Add a new `entity.py` with `build_device_info` and replace duplicated `DeviceInfo` constructions in `sensor.py`, `select.py`, and `number.py`. 
- Minor import/formatting cleanup and update docs in `docs/handover.md` and `docs/protocol.md` to mention the bit-packed timers and inferred timer-count.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6ecf8f8883338ee985eb6debba22)